### PR TITLE
New syntax to insert hex numbers

### DIFF
--- a/InsertNums.py
+++ b/InsertNums.py
@@ -22,6 +22,11 @@ class InsertNumsCommand(sublime_plugin.TextCommand):
         if current in self.digits:
             def tick(counter):
                 return str('%0*d' % (int(padding), int(current) + counter))
+                
+        elif current[0] == 'x':
+            current = int(current[1:])
+            def tick(counter):
+                return str('%0*x' % (int(padding), int(current) + counter))
 
         elif current in self.alpha:
             current = self.decode(current)


### PR DESCRIPTION
Hello,

I added new invented syntax to insert hex numbers: the syntax is "xn" where n contains the starting number. This will insert hex numbers in place of plain digits
All other features from InsertNumbers still works

I'm not a Python expert at all, but this change is quite important in my workflow (I'm mainly programming in C).
