### PR TITLE
removed trailing comma that causing error message on opening in OSX

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
 	{ "keys": ["super+alt+n"], "command": "prompt_insert_nums" },
-	{ "keys": ["super+shift+alt+n"], "command": "prompt_insert_nums", "args": { "automatic": false } },
+	{ "keys": ["super+shift+alt+n"], "command": "prompt_insert_nums", "args": { "automatic": false } }
 ]


### PR DESCRIPTION
Just removing a trailing comma that was displaying an alert
